### PR TITLE
Add clean menus option to grounditems plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -115,16 +115,16 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-	
+
 	@ConfigItem(
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
 		position = 6
 	)
-	default boolean highlightTiles() 
-	{ 
-		return false; 
+	default boolean highlightTiles()
+	{
+		return false;
 	}
 
 	@ConfigItem(
@@ -336,4 +336,14 @@ public interface GroundItemsConfig extends Config
 		return 250;
 	}
 
+	@ConfigItem(
+			keyName = "menuGroupingEnabled",
+			name = "Enable menu grouping",
+			description = "Groups together duplicate entries in the menu",
+			position = 26
+	)
+	default boolean isMenuGroupingEnabled()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/MenuGroupingEntry.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/MenuGroupingEntry.java
@@ -1,0 +1,20 @@
+package net.runelite.client.plugins.grounditems;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.MenuEntry;
+
+@AllArgsConstructor
+class MenuGroupingEntry
+{
+	@Getter
+	private MenuEntry originalEntry;
+
+	@Getter
+	private int position;
+
+	@Getter
+	@Setter
+	private int count;
+}


### PR DESCRIPTION
Added code to cleanup duplicate entries in menus
Added config option to enable (disabled by default)